### PR TITLE
Add iOS 26 liquid glass style

### DIFF
--- a/css/ios26.css
+++ b/css/ios26.css
@@ -1,0 +1,31 @@
+/* iOS 26 inspired theme */
+body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    background: #f5f5f7;
+    color: #111;
+}
+
+header.site-header {
+    backdrop-filter: blur(20px) saturate(180%);
+    -webkit-backdrop-filter: blur(20px) saturate(180%);
+    background: rgba(255, 255, 255, 0.4);
+    border-bottom: 1px solid rgba(255, 255, 255, 0.6);
+    box-shadow: 0 1px 10px rgba(0,0,0,0.1);
+}
+
+footer.site-footer {
+    backdrop-filter: blur(20px) saturate(180%);
+    -webkit-backdrop-filter: blur(20px) saturate(180%);
+    background: rgba(255, 255, 255, 0.4);
+    border-top: 1px solid rgba(255, 255, 255, 0.6);
+    box-shadow: 0 -1px 10px rgba(0,0,0,0.05);
+}
+
+/* utility glass class */
+.glass {
+    backdrop-filter: blur(20px) saturate(180%);
+    -webkit-backdrop-filter: blur(20px) saturate(180%);
+    background: rgba(255,255,255,0.4);
+    border: 1px solid rgba(255,255,255,0.6);
+    box-shadow: 0 4px 30px rgba(0,0,0,0.1);
+}

--- a/index.html
+++ b/index.html
@@ -189,6 +189,7 @@ flexibility(document.documentElement);
 			.ast-desktop .main-header-menu .sub-menu {
 background-color: black;
 }		</style>
+<link rel="stylesheet" href="css/ios26.css" media="all">
 		</head>
 
 <body itemtype="https://schema.org/WebPage" itemscope="itemscope" class="home wp-singular page-template-default page page-id-4 wp-theme-astra cookies-not-set ast-header-break-point ast-page-builder-template ast-no-sidebar astra-4.11.8 ast-single-post ast-inherit-site-logo-transparent ast-theme-transparent-header ast-hfb-header ast-normal-title-enabled elementor-default elementor-kit-214 elementor-page elementor-page-4">
@@ -197,7 +198,7 @@ background-color: black;
 		Ga naar de inhoud</a>
 
 <div class="hfeed site" id="page">
-			<header class="site-header header-main-layout-1 ast-primary-menu-enabled ast-logo-title-inline ast-hide-custom-menu-mobile ast-builder-menu-toggle-icon ast-mobile-header-inline" id="masthead" itemtype="https://schema.org/WPHeader" itemscope="itemscope" itemid="#masthead">
+			<header class="site-header glass header-main-layout-1 ast-primary-menu-enabled ast-logo-title-inline ast-hide-custom-menu-mobile ast-builder-menu-toggle-icon ast-mobile-header-inline" id="masthead" itemtype="https://schema.org/WPHeader" itemscope="itemscope" itemid="#masthead">
 			<div id="ast-desktop-header" data-toggle-type="dropdown">
 		<div class="ast-below-header-wrap  ">
 		<div class="ast-below-header-bar ast-below-header  site-header-focus-item" data-section="section-below-header-builder">


### PR DESCRIPTION
## Summary
- create new CSS theme for iOS 26 look with liquid glass effect
- apply new style to the site header and footer
- include the new stylesheet in the page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688b7f784f80832aa408bef51d72a5a9